### PR TITLE
Fix whitespace in stream decoder

### DIFF
--- a/lib/libqp.js
+++ b/lib/libqp.js
@@ -285,7 +285,7 @@ class Decoder extends Transform {
 
         qp = this._curLine + chunk;
         this._curLine = '';
-        qp = qp.replace(/\=[^\n]?$/, lastLine => {
+        qp = qp.replace(/[\t ]*(?:=[^\n]?)?$/, lastLine => {
             this._curLine = lastLine;
             return '';
         });

--- a/test/libqp-test.js
+++ b/test/libqp-test.js
@@ -39,3 +39,163 @@ test('Encoding tests', async t => {
         assert.strictEqual(encoded, 'tere j=C3=B5geva');
     });
 });
+
+test('Decoding tests', async t => {
+    // Example taken from RFC2045 section 6.7
+    const encoded =
+        "Now's the time =\r\n" +
+        "for all folk to come=\r\n" +
+        " to the aid of their country."
+    const expectedDecoded =
+        "Now's the time for all folk to come to the aid of their country."
+
+    await t.test('simple string', async () => {
+        const decoded = libqp.decode(encoded).toString();
+        assert.strictEqual(decoded, expectedDecoded);
+    });
+
+    await t.test('stream', async () => {
+        const decoder = new libqp.Decoder();
+
+        const decoded = await new Promise((resolve, reject) => {
+            const chunks = [];
+            decoder.on('readable', () => {
+                let chunk;
+
+                while ((chunk = decoder.read()) !== null) {
+                    chunks.push(chunk);
+                }
+            });
+            decoder.on('end', () => {
+                resolve(Buffer.concat(chunks).toString());
+            });
+            decoder.on('Error', err => {
+                reject(err);
+            });
+
+            decoder.end(Buffer.from(encoded));
+        });
+
+        assert.strictEqual(decoded, expectedDecoded);
+    });
+
+    await t.test('stream, multiple chunks', async () => {
+        const encodedChunk1Length = 3;
+        const encodedChunk1 = encoded.substring(0, encodedChunk1Length)
+        const encodedChunk2 = encoded.substring(encodedChunk1Length)
+
+        const decoder = new libqp.Decoder();
+
+        const decoded = await new Promise((resolve, reject) => {
+            const chunks = [];
+            decoder.on('readable', () => {
+                let chunk;
+
+                while ((chunk = decoder.read()) !== null) {
+                    chunks.push(chunk);
+                }
+            });
+            decoder.on('end', () => {
+                resolve(Buffer.concat(chunks).toString());
+            });
+            decoder.on('Error', err => {
+                reject(err);
+            });
+
+            decoder.write(Buffer.from(encodedChunk1));
+            decoder.end(Buffer.from(encodedChunk2));
+        });
+
+        assert.strictEqual(decoded, expectedDecoded);
+    });
+
+    await t.test('stream, space at end of chunk', async () => {
+        const encodedChunk1Length = encoded.indexOf(' ') + 1;
+        const encodedChunk1 = encoded.substring(0, encodedChunk1Length)
+        const encodedChunk2 = encoded.substring(encodedChunk1Length)
+
+        const decoder = new libqp.Decoder();
+
+        const decoded = await new Promise((resolve, reject) => {
+            const chunks = [];
+            decoder.on('readable', () => {
+                let chunk;
+
+                while ((chunk = decoder.read()) !== null) {
+                    chunks.push(chunk);
+                }
+            });
+            decoder.on('end', () => {
+                resolve(Buffer.concat(chunks).toString());
+            });
+            decoder.on('Error', err => {
+                reject(err);
+            });
+
+            decoder.write(Buffer.from(encodedChunk1));
+            decoder.end(Buffer.from(encodedChunk2));
+        });
+
+        assert.strictEqual(decoded, expectedDecoded);
+    });
+
+    await t.test('stream, soft line break equals sign at end of chunk', async () => {
+        const encodedChunk1Length = encoded.indexOf('=') + 1;
+        const encodedChunk1 = encoded.substring(0, encodedChunk1Length)
+        const encodedChunk2 = encoded.substring(encodedChunk1Length)
+
+        const decoder = new libqp.Decoder();
+
+        const decoded = await new Promise((resolve, reject) => {
+            const chunks = [];
+            decoder.on('readable', () => {
+                let chunk;
+
+                while ((chunk = decoder.read()) !== null) {
+                    chunks.push(chunk);
+                }
+            });
+            decoder.on('end', () => {
+                resolve(Buffer.concat(chunks).toString());
+            });
+            decoder.on('Error', err => {
+                reject(err);
+            });
+
+            decoder.write(Buffer.from(encodedChunk1));
+            decoder.end(Buffer.from(encodedChunk2));
+        });
+
+        assert.strictEqual(decoded, expectedDecoded);
+    });
+
+    await t.test('stream, CR at end of chunk', async () => {
+        const encodedChunk1Length = encoded.indexOf('\r') + 1;
+        const encodedChunk1 = encoded.substring(0, encodedChunk1Length)
+        const encodedChunk2 = encoded.substring(encodedChunk1Length)
+
+        const decoder = new libqp.Decoder();
+
+        const decoded = await new Promise((resolve, reject) => {
+            const chunks = [];
+            decoder.on('readable', () => {
+                let chunk;
+
+                while ((chunk = decoder.read()) !== null) {
+                    chunks.push(chunk);
+                }
+            });
+            decoder.on('end', () => {
+                resolve(Buffer.concat(chunks).toString());
+            });
+            decoder.on('Error', err => {
+                reject(err);
+            });
+
+            decoder.write(Buffer.from(encodedChunk1));
+            decoder.end(Buffer.from(encodedChunk2));
+        });
+
+        assert.strictEqual(decoded, expectedDecoded);
+    });
+});


### PR DESCRIPTION
### How does this PR improve libqp?

Without this PR, when decoding a quoted-printable stream, some spaces will get silently dropped, depending on stream chunk boundaries. With this PR, spaces and tabs are preserved as specified in RFC2045.

### Steps to reproduce the issue

Run the tests in this PR. Without this PR, 3 tests will fail:

- [Space at the end of a chunk](https://github.com/nahne/libqp/blob/1ed3f83e482659fb60b21c20fb1bae05ed576d1a/test/libqp-test.js#L112-L140)
- [Equals sign of a soft line break at the end of a chunk](https://github.com/nahne/libqp/blob/1ed3f83e482659fb60b21c20fb1bae05ed576d1a/test/libqp-test.js#L142-L170)
- [CR of a soft line break at the end of a chunk](https://github.com/nahne/libqp/blob/1ed3f83e482659fb60b21c20fb1bae05ed576d1a/test/libqp-test.js#L172-L200)

### Expected behavior

The decoded data should not change when the encoded data is provided in multiple stream chunks.

### Actual behavior

Spaces and tabs are discarded, even though they should be preserved per RFC2045.

### Related issues

We discovered the behavior when using nodemailer to parse quoted-printable encoded PDF attachments.

[nodemailer #379: quoted-printable attachment missing some tabs](https://github.com/nodemailer/mailparser/issues/379) might be related 

